### PR TITLE
slime-eval-region command

### DIFF
--- a/swank-handler.js
+++ b/swank-handler.js
@@ -144,6 +144,7 @@ Handler.prototype.receive = function receive (message) {
     this.executive[d.form.name == "js:set-target-url" ? "setTargetUrl" : "setSlimeVersion"](expr);
     break;
   case "swank:interactive-eval":
+  case "swank:interactive-eval-region":
   case "swank:listener-eval":
     if (d.form.args.length != 1) {
       console.log("bad args len for SWANK:LISTENER-EVAL -- %s", d.form.args.length);


### PR DESCRIPTION
Maybe I'm doing it wrong, but this allows communicate to node with slime-eval-region and not using MozRepl.
I'm not using js2-mode (espresso for now).
Do I get it right that with js2 MozRepl is hijacked to communicate with node instead of browser?
With espresso it tries to connect to browser, but all I need is node repl, so this allows me to have it.

I'm not sure though that this is the right way to handle interactive-eval-region, but it does the job for me, so feel free to throw it away.
