### PR TITLE
Fixing document.head missing on IE7/8

### DIFF
--- a/client/swank-js-inject.js
+++ b/client/swank-js-inject.js
@@ -19,6 +19,7 @@ function load(url, requirement) {
   var script = document.createElement('script');
   script.setAttribute('type', 'text/javascript');
   script.setAttribute('src', swank_server + url);
+  document.head = document.head || document.getElementsByTagName('head')[0];
   document.head.appendChild(script);
 }
 


### PR DESCRIPTION
Paired with my other pull request, this gets swank-js working for IE7/8.
