### PR TITLE
Remove parameters when comparing file names in refreshCSS.

### DIFF
--- a/client/swank-js.js
+++ b/client/swank-js.js
@@ -272,7 +272,7 @@ SwankJS.refreshCSS = function refreshCSS (filename) {
     var link = links[i];
     if (link.rel.toLowerCase().indexOf('stylesheet') == -1 || !link.href) continue;
     var h = link.href.replace(/(&|\?)forceReload=\d+/, ""),
-        hrefFilename = h.replace(/^.*\//g, "");
+        hrefFilename = h.replace(/^.*\//g, "").replace(/\?.*$/, "");
     if (filename && hrefFilename != filename) continue;
     link.href = h + (h.indexOf('?') >= 0 ? '&' : '?') + 'forceReload=' +
       (Date.now ? Date.now() : +new Date());


### PR DESCRIPTION
- When refreshing a specific css file, the refreshCSS script compares filenames.
- Links to the css file may include cache-busters, like base.css?dontCache=[timestamp]
- These should be stripped off, to be able to compare just the file names.
