### PR TITLE
Add a ,require shortcut to load node.js modules with tab-completion

### DIFF
--- a/swank-handler.js
+++ b/swank-handler.js
@@ -165,6 +165,12 @@ Handler.prototype.receive = function receive (message) {
     }
     this.executive[d.form.name == "js:set-target-url" ? "setTargetUrl" : "setSlimeVersion"](expr);
     break;
+  case "js:list-module-paths":
+    r.result = toLisp({ paths: module.paths }, [S(":paths"), "R:paths"]);
+    break;
+  case "js:module-filename":
+    r.result = toLisp({ filename: module.filename }, [S(":filename"), "s:filename"]);
+    break;
   case "swank:interactive-eval":
   case "swank:interactive-eval-region":
   case "swank:listener-eval":


### PR DESCRIPTION
Hi,
I just started using swank-js to help debug a node project this week and I have a few small enhancements that maybe other people will also find useful. This is number 1 of 3. It adds a `,require` shortcut to the REPL to load modules quickly since I get tired of typing things like `http = require('http')` all the time. It does tab completion on core modules, modules in `node_modules` directories and relative file paths.

There are two tiny extra commands in `swank-handler.js` to return paths, and a few definitions in `slime-js.el`.

One useful thing that I couldn't figure out how to do is detect whether the current remote is a node process or a browser, since it's only useful on the former. But nothing bad happens if you use it on a browser instead (just complains that `require` isn't defined).
