### PR TITLE
Add inspect() function to the repl for async debugging

### DIFF
--- a/swank-handler.js
+++ b/swank-handler.js
@@ -300,8 +300,17 @@ function DefaultRemote () {
   this.context._swank = {
     output: function output (arg) {
       self.output(arg);
+    },
+
+    inspect: function inspect () {
+      Array.prototype.forEach.call(arguments, function (arg) {      
+        self.output(util.inspect(arg, false, 10));
+        self.output('\n');
+      }); 
     }
+    
   };
+  this.context.inspect = this.context._swank.inspect;
 }
 
 util.inherits(DefaultRemote, Remote);


### PR DESCRIPTION
Debugging asynchronous node functions in a REPL is tricky when they take a callback but don't return a value to display immediately.

This patch adds an  `inspect` function to the REPL which calls `util.inspect()` on each of its arguments and prints the results to the REPL output, so you can pass it as a callback to any asynchronous function. I put it in the `_swank` namespace and also bind it to `inspect` in the REPL's global context. This means it's quick to type, and if you overwrite it with some other value you can still get it from `_swank.inspect`.
