### PR TITLE
fix error handling for chrome

### DIFF
--- a/client/stacktrace.js
+++ b/client/stacktrace.js
@@ -141,7 +141,7 @@ swank_printStackTrace.implementation.prototype = {
      * @return Array<String> of function calls, files and line numbers
      */
     chrome: function(e) {
-        return e.stack.replace(/^[^\n]*\n/, '').replace(/^[^\n]*\n/, '').replace(/^[^\(]+?[\n$]/gm, '').replace(/^\s+at\s+/gm, '').replace(/^Object.<anonymous>\s*\(/gm, '{anonymous}()@').split('\n');
+        return e.stack ? e.stack.replace(/^[^\n]*\n/, '').replace(/^[^\n]*\n/, '').replace(/^[^\(]+?[\n$]/gm, '').replace(/^\s+at\s+/gm, '').replace(/^Object.<anonymous>\s*\(/gm, '{anonymous}()@').split('\n') : [];
     },
 
     /**


### PR DESCRIPTION
errors were hanging the connection on chrome 22
 (don't know about prior versions)
change should be safe, just checking for a property before
accessing it.
