### PR TITLE
fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 swank-js
 ========
 
-NOTE: the official repo is at [[https://github.com/swank-js/swank-js]].
+NOTE: the official repo is at [[https://github.com/swank-js/swank-js ]].
 
 swank-js provides [SLIME](http://common-lisp.net/project/slime/) REPL
 and other development tools for in-browser JavaScript and


### PR DESCRIPTION
the link to the official repo in the readme is broken.  The trailing right square bracket ] is included in the url like https://github.com/swank-js/swank-js%5D.
