### PR TITLE
swank:create-repl was moved to the swank-repl package, and

### DIFF
--- a/swank-handler.js
+++ b/swank-handler.js
@@ -118,7 +118,7 @@ Handler.prototype.receive = function receive (message) {
         cont();
       });
     return;
-  case "swank:create-repl":
+  case "swank-repl:create-repl":
     r.result = toLisp(this.executive.createRepl(), ["s:packageName", "s:prompt"]);
     break;
   case "swank:autodoc":
@@ -177,7 +177,7 @@ Handler.prototype.receive = function receive (message) {
     break;
   case "swank:interactive-eval":
   case "swank:interactive-eval-region":
-  case "swank:listener-eval":
+  case "swank-repl:listener-eval":
     if (d.form.args.length != 1) {
       console.log("bad args len for SWANK:LISTENER-EVAL -- %s", d.form.args.length);
       return; // FIXME


### PR DESCRIPTION
so was swank:listener-eval.  However, swank-handler.js had not been
update to reflect the change.  This commit fixes that.
